### PR TITLE
Memoize the reverseUrl filter using lodash.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+# 2.0.0
+
+* Added lodash as a dependency.
+* Memoized the reverseUrl filter. Massive performance benefits from this.
+  Every $digest cycle causes all URLs to be reversed, even if they haven't
+  changed.
+
 # 1.0.0
 
 * Initial release.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-reverse-url",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/incuna/angular-reverse-url",
   "authors": [
     "Perry Roper <perryroper@gmail.com>"
@@ -21,6 +21,7 @@
   ],
   "dependencies": {
     "angular": "1.2.7",
-    "angular-route": "1.2.7"
+    "angular-route": "1.2.7",
+    "lodash": "~2.4.1"
   }
 }

--- a/reverse_url.js
+++ b/reverse_url.js
@@ -5,7 +5,7 @@
         .filter('reverseUrl', ['$route', function ($route) {
             var regexp = /:([A-Za-z0-9]*)\\*?\\??/g;
 
-            return function (controller, params) {
+            return _.memoize(function (controller, params) {
                 var targetRoute;
                 angular.forEach($route.routes, function (route) {
                     if (route.controller === controller) {
@@ -17,6 +17,8 @@
                     return params[pattern];
                 });
                 return '#' + targetRoute;
-            };
+            }, function (controller, params) {
+                return controller + JSON.stringify(params);
+            });
         }]);
 }());


### PR DESCRIPTION
The following tests were conducted on a basic page with a few URLs being reversed. This is just from page load. A few minutes interacting with a page, and the filter was being called **tens of thousands** of times. After the optimisations, 20 calls on load and 0 extra after causing a few $digest cycles.
# Before

![](http://i.imgur.com/kE5RfuO.png)
# After

![](http://i.imgur.com/4BwSmZa.png)
