### PR TITLE
Return the empty string if no route is found.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 2.2.0
+
+* Return the empty string if no route matches.
+
 # 2.1.0
 
 * Allow routes to be resolved by the `name` property.

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-reverse-url",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "homepage": "https://github.com/incuna/angular-reverse-url",
   "authors": [
     "Perry Roper <perryroper@gmail.com>"

--- a/src/reverse_url.js
+++ b/src/reverse_url.js
@@ -27,6 +27,9 @@
                         }
                     }
                 });
+                if (angular.isUndefined(targetRoute)) {
+                    return '';
+                }
                 targetRoute = targetRoute.replace(regexp, function (match, pattern) {
                     return params[pattern];
                 });

--- a/test/reverse_urlSpec.js
+++ b/test/reverse_urlSpec.js
@@ -54,6 +54,10 @@
                 expect(reverseUrl('TestRoute2', {param: 'foobar'})).toEqual('#/test-route-2/foobar/');
             });
 
+            it('should return the empty string if the route does not match', function () {
+                expect(reverseUrl('MissingController')).toEqual('');
+            });
+
         });
 
     });


### PR DESCRIPTION
Currently the filter raises an exception if no route matches. This PR updates it to return the empty string.