### PR TITLE
Updated bower.json to fix main src path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,11 +1,11 @@
 {
   "name": "angular-reverse-url",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "homepage": "https://github.com/incuna/angular-reverse-url",
   "authors": [
     "Perry Roper <perryroper@gmail.com>"
   ],
-  "main": "reverse_url.js",
+  "main": "src/reverse_url.js",
   "keywords": [
     "angularjs",
     "reverse",


### PR DESCRIPTION
The `bower.json` `main` value is incorrect, this leads to bugs in libraries parsing it (we had such a problem using wiredep).
I also updated the version.